### PR TITLE
Bugfix/exception GitHub license page

### DIFF
--- a/lib/src/services/dependency_report.dart
+++ b/lib/src/services/dependency_report.dart
@@ -77,7 +77,8 @@ class DependencyReport {
 
     final gitDeps = <Dependency>[];
     for (final package in git) {
-      final license = await GitHubScraper.licenseForPackage(package.url);
+      final license =
+          package.isHostedByCustomGit('github') ? await GitHubScraper.licenseForPackage(package.url) : _defaultText;
       gitDeps.add(Dependency(
         name: package.package(),
         version: package.version(),

--- a/lib/src/services/github_scraper.dart
+++ b/lib/src/services/github_scraper.dart
@@ -3,13 +3,15 @@ import 'package:web_scraper/web_scraper.dart';
 class GitHubScraper {
   static Future<String> licenseForPackage(String url) async {
     final _webScraper = WebScraper('$url');
-    if (await _webScraper.loadWebPage('/blob/master/LICENSE')) {
-      final regExp = RegExp(r'(<h3 class=\"mt-0 mb-2 h4\">)(.*)(<\/h3>)');
-      final matches = regExp.allMatches(_webScraper.getPageContent());
-      final license = matches?.first?.group(2)?.replaceAll('License', '')?.trim();
+    try {
+      if (await _webScraper.loadWebPage('/blob/master/LICENSE')) {
+        final regExp = RegExp(r'(<h3 class=\"mt-0 mb-2 h4\">)(.*)(<\/h3>)');
+        final matches = regExp.allMatches(_webScraper.getPageContent());
+        final license = matches?.first?.group(2)?.replaceAll('License', '')?.trim();
 
-      return license;
-    }
+        return license;
+      }
+    } on WebScraperException catch (_) {}
 
     return 'Unknown';
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -461,12 +461,10 @@ packages:
   web_scraper:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "feature/remove-dependency-on-flutter"
-      resolved-ref: a6e1b9cae94a2d915b5aa11c98ee9c5e82b9cc92
-      url: "https://github.com/defuncart/fork_web_scraper"
-    source: git
-    version: "0.0.5"
+      name: web_scraper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.6"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,7 @@ dependencies:
   pubspec_lock: ^2.0.1
   pubspec_yaml: ^2.0.1
   pdf: 1.8.1
-  web_scraper:
-    git:
-      url: https://github.com/defuncart/fork_web_scraper
-      ref: feature/remove-dependency-on-flutter
+  web_scraper: 0.0.6
 
 dev_dependencies:
   test: ^1.15.0


### PR DESCRIPTION
Fixes a bug where non-github git dependencies would trigger an exception when scrapped. Updates to web_scraper 0.0.6.